### PR TITLE
Add YIP-43 - Add New Statuses to YIP Proposals 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
 # YIPs [![Discord](https://img.shields.io/discord/734804446353031319.svg?color=768AD4&label=discord&logo=https%3A%2F%2Fdiscordapp.com%2Fassets%2F8c9701b98ad4372b58f13fd9f65f966e.svg)](https://discordapp.com/channels/734804446353031319/) [![Telegram](https://img.shields.io/badge/chat-on%20Telegram-blue.svg)](https://t.me/yearnfinance) [![Twitter Follow](https://img.shields.io/twitter/follow/iearnfinance.svg?label=iearnfinance&style=social)](https://twitter.com/iearnfinance)
+
 yEarn Improvement Proposals (YIPs) describe standards for the yEarn platform, including core protocol specifications, client APIs, and contract standards.
 
-# Contributing
+- [YIPs](#yips)
+  * [Contributing](#contributing)
+  * [YIP Statuses](#yip-statuses)
+  * [Validation](#validation)
+  
+ 
+## Contributing
 
  1. Review [YIP-0](YIPS/yip-0.md).
  2. Fork the repository by clicking "Fork" in the top right.
@@ -14,15 +21,18 @@ If your YIP requires images, the image files should be included in a subdirector
 
 When you believe your YIP is mature and ready to progress past the WIP phase, you should ask to have your issue added to the next governance call where it can be discussed for inclusion in a future platform upgrade. If the community agrees to include it, the YIP editors will update the state of your YIP to 'Approved'.
 
-# YIP Statuses
+## YIP Statuses
 
 * **WIP** - a YIP that is still being developed.
 * **Proposed** - a YIP that is ready to be reviewed in a governance call.
 * **Approved** - a YIP that has been accepted for implementation by the yEarn community.
 * **Implemented** - a YIP that has been released to mainnet.
 * **Rejected** - a YIP that has been rejected.
+* **Withdrawn** - a YIP that has been withdrawn by the author(s).
+* **Deferred** - a YIP that governance has decided to wait for another YIP/some other change that should be bundled with it together
+* **Moribund** - a YIP that was once Implemeneted. It is now Obsolete 'AND' requires no explicit replacement.
 
-# Validation
+## Validation
 
 YIPs must pass some validation tests.  The YIP repository ensures this by running tests using [html-proofer](https://rubygems.org/gems/html-proofer) and [yip_validator](https://rubygems.org/gems/yip_validator).
 
@@ -31,3 +41,7 @@ It is possible to run the YIP validator locally:
 gem install yip_validator
 yip_validator <INPUT_FILES>
 ```
+
+## License 
+
+CC-0

--- a/YIPS/yip-0.md
+++ b/YIPS/yip-0.md
@@ -8,6 +8,25 @@ created: 2020-07-22
 updated: N/A
 ---
 
+## Table of Contents 
+
+- [What is an YIP?](#what-is-an-yip-)
+- [YIP Rationale](#yip-rationale)
+- [YIP Work Flow](#yip-work-flow)
+- [What belongs in a successful YIP?](#what-belongs-in-a-successful-yip-)
+- [YIP Formats and Templates](#yip-formats-and-templates)
+- [YIP Header Preamble](#yip-header-preamble)
+    + [`author` header](#-author--header)
+    + [`discussions-to` header](#-discussions-to--header)
+    + [`created` header](#-created--header)
+    + [`updated` header](#-updated--header)
+    + [`requires` header](#-requires--header)
+- [Auxiliary Files](#auxiliary-files)
+- [YIP Editors](#yip-editors)
+- [YIP Editor Responsibilities](#yip-editor-responsibilities)
+- [History](#history)
+  * [Bibliography](#bibliography)
+
 ## What is an YIP?
 
 YIP stands for yEarn Improvement Proposal, it has been adapted from the SIP (Synthetix Improvement Proposal). The purpose of this process is to ensure changes to yEarn are transparent and well governed. An YIP is a design document providing information to the yEarn community about a proposed change to the system. The author is responsible for building consensus within the community and documenting dissenting opinions.
@@ -29,7 +48,13 @@ Parties involved in the process are the *author*, the [*YIP editors*](#yip-edito
 Your role as the champion is to write the YIP using the style and format described below, shepherd the discussions in the appropriate forums, and build community consensus around the idea. Following is the process that a successful YIP will move along:
 
 ```
-[ WIP ] -> [ PROPOSED ] -> [ APPROVED ] -> [ IMPLEMENTED ] X [ REJECTED ] 
+Proposed -> Approved -> Implemented
+  ^                     |
+  +----> Rejected       +----> Moribund
+  |
+  +----> Withdrawn
+  v
+Deferred
 ```
 
 Each status change is requested by the YIP author and reviewed by the YIP editors. Use a pull request to update the status. Please include a link to where people should continue discussing your YIP. The YIP editors will process these requests as per the conditions below.
@@ -41,6 +66,11 @@ Each status change is requested by the YIP author and reviewed by the YIP editor
 * **Implemented** -- This YIP has been implemented and deployed to mainnet.
 
 * **Rejected** -- This YIP has failed to reach community consensus.
+
+* **Withdrawn** -- Means that the YIP author has decided that the YIP is actually a bad idea, or has accepted that a competing proposal is a better alternative.
+* **Moribund** -- Obsolete and requires no explicit replacement, it SHOULD be marked "Moribund"
+* **Deferred** -- Governance placed status upon a YIP that means that they would like to know more information, or that they would like to see if the author(s) can work with another proposed YIP and combine it into a single YIP, etc.
+
 
 ## What belongs in a successful YIP?
 

--- a/YIPS/yip-43-improve-statuses.md
+++ b/YIPS/yip-43-improve-statuses.md
@@ -1,13 +1,11 @@
 ---
-yip: <to be assigned>
-title: improve-yip-categories
-status: WIP 
+yip: 43
+title: Improve YIP categories
+status: Proposed
 author: sam bacha, @sambacha <sam@freighttrust.com>
 discussions-to: https://gov.yearn.finance/t/proposal-add-new-statuses-to-yip-proposals-non-protocol-change/3608
 
 created: 2020-08-24
-requires (*optional): <YIP number(s)>
-implementation (*optional): <Added if YIP passes>
 ---
 
 

--- a/YIPS/yip-xx-improve-statuses.md
+++ b/YIPS/yip-xx-improve-statuses.md
@@ -1,0 +1,154 @@
+---
+yip: <to be assigned>
+title: improve-yip-categories
+status: WIP 
+author: sam bacha, @sambacha <sam@freighttrust.com>
+discussions-to: https://gov.yearn.finance/t/proposal-add-new-statuses-to-yip-proposals-non-protocol-change/3608
+
+created: 2020-08-24
+requires (*optional): <YIP number(s)>
+implementation (*optional): <Added if YIP passes>
+---
+
+
+## Simple Summary
+<!--"If you can't explain it simply, you don't understand it well enough." Simply describe the outcome the proposed changes intends to achieve. This should be non-technical and accessible to a casual community member.-->
+
+Add new `status`(s) to `YIPs` so that author(s) may better manage their `YIPs` in the context of community collaboration and so that governance is given the proper procedures to foster community cooperation.
+
+## Abstract
+<!--A short (~200 word) description of the proposed change, the abstract should clearly describe the proposed change. This is what *will* be done if the YIP is implemented, not *why* it should be done or *how* it will be done. If the YIP proposes deploying a new contract, write, "we propose to deploy a new contract that will do x".-->
+
+
+This will *only* add to the current state of `proposal YIPs` in that it only changes the _potential_ `statuses` available of a `YIP`. It does not add any `protocol` changes: only documentation and governance procedures (off chain only).
+
+I proposal the following changes to reflect a new state of possible 'YIPs':
+
+1. Modifying YIP Templates
+2. Modifying YIP Validator Gemfile
+3. Modifying YIP README file
+
+
+## Motivation
+<!--This is the problem statement. This is the *why* of the YIP. It should clearly explain *why* the current state of the protocol is inadequate.  It is critical that you explain *why* the change is needed, if the YIP proposes changing how something is calculated, you must address *why* the current calculation is inaccurate or wrong. This is not the place to describe how the YIP will address the issue!-->
+> The current state of procedures for `YIPS` is inadequate as it unnecessarily limits the possible outcomes of a proposed `YIP` while not affording both the author(s) nor the governance council flexibility in being able to deal with community driven `YIPs`
+
+This is a *documentation* and *procedure* change. In fact there is no explicit description for proposing such changes in governance *(that I could find).*
+
+This change is needed as it better explains the *intent* of the YIP format to author(s). It also provides for governance additional functionality in their procedures so as to not potentially 'alienate' author(s) by rejecting a YIP when it could have been withdrawn. This ensures that also the author(s) are active in the process of their submitted proposal and in the larger community (in so far as they are knowledgable about other potentially competing YIPS.)
+
+## Specification
+
+*Additions in 'BOLD'*
+
+Proposed - a YIP that is ready to be reviewed in a governance call.
+Approved - a YIP that has been accepted for implementation by the yEarn community.
+Implemented - a YIP that has been released to mainnet.
+Rejected - a YIP that has been rejected.
+**Withdrawn - a YIP that has been withdrawn by the author(s).**
+**Deferred - a YIP that governance has decided to wait for another YIP/some other change that should be bundled with it together**
+**Moribund - a YIP that was once Implemented. It is now Obsolete 'AND' requires no explicit replacement.**
+
+The "Withdrawn" status is similar - it means that the YIP author has decided that the YIP is actually a 'bad' idea, or has accepted that a competing proposal is a better alternative.
+
+
+### Workflow Specification
+```
+Proposed -> Approved -> Implemented
+  ^                     |
+  +----> Rejected       +----> Moribund
+  |
+  +----> Withdrawn
+  v
+Deferred
+```
+
+
+#### New Statuses for YIPs 
+
+> To be added are the following
+
+[Withdrawn](/EfryOm69Sf-iM4TCasQuJA)
+[Moribund](/igo8dKVnRjq8Xxyql9GOxQ)
+[Deferred](/MPwJ8Sa2Se-7qFBlEvDEBw)
+
+
+### Overview
+<!--This is a high level overview of *how* the YIP will solve the problem. The overview should clearly describe how the new feature will be implemented.-->
+
+#### New YIP statuses
+- Withdrawn
+Means that the YIP author has decided that the YIP is actually a bad idea, or has accepted that a competing proposal is a better alternative.
+- Moribund
+Obsolete and requires no explicit replacement, it SHOULD be marked "Moribund"
+- Deferred
+Governance placed status upon a YIP that means that they would like to know more information, or that they would like to see if the author(s) can work with another proposed YIP and combine it into a single YIP, etc.
+
+
+### Rationale
+
+The reasoning behind this is that it is unclear what will happen to a YIP should material facts change during its initial formal proposal and when its actually voted on by governance. Changes may be introduced between then, and the author may want to withdraw the proposal. This also frees up the governance council in that they are no longer obligated to reject every single YIP that may no longer be relevant, instead sharing the responsibility with the actual author(s). 
+
+### Technical Specification
+<!--
+NOTE: NO PROTOCOL CHANGES ARE PROPOSED 
+THE ONLY TECHNICAL CHANGES ARE IN THE RUBY VALIDATION PROCESS FOR YIPS
+-->
+Technical implementation involves:
+
+* changes in the validation Gemfile 
+* changes in the template `.md` file
+
+#### Changes in Template `.md` file
+
+Below is a sample `.yaml` file to illustrate the _new_ header that should be used in the `yip-template.md` file
+
+```yaml
+---
+YIP: <YIP number>
+Title: <YIP title>
+Author: < firstName, lastName, @githubUsrName, contact@address.com >
+Type: <Informational | Standards Track>
+Status: <WIP | Proposed | Approved | Deferred | Withdrawn | Rejected |
+           Implemented | Replaced | Moribund>
+    Version: <major>[.<minor>]
+    Created: <date created on, in ISO 8601 (yyyy-mm-dd) format>
+    Requires (*optional): <YIP number(s)>
+    Implementation (*optional): <Added if YIP passes>
+
+Discussions-to: <Create a new thread on https://gov.yearn.finance/ and drop the link here>
+
+* Requires: <YIP numbers>
+* Replaces: <YIP numbers>
+* Replaced-By: <YIP number>
+---
+```
+
+#### YIP Validator (Ruby Gem)
+
+> current version: `1.0.2`, should be bumped to `1.1.0`
+Changes located [github.com/iearn-finance/yip_validator/blob/master/lib/yip_validator/validator.rb#L25](https://github.com/iearn-finance/yip_validator/blob/master/lib/yip_validator/validator.rb#L25)
+
+```ruby
+    validates_inclusion_of :status, in: ['WIP', 'Proposed', 'Approved', 'Implemented', 'Rejected']
+```
+```ruby
+    validates_inclusion_of :status, in: ['WIP', 'Proposed', 'Approved', 'Implemented', 'Rejected', 'Withdrawn', 'Deferred', 'Moribund']
+```
+
+See Files Changed here [https://github.com/sambacha/yip_validator/tree/YIP-Proposed](https://github.com/sambacha/yip_validator/tree/YIP-Proposed)
+
+### Test Cases
+
+See `travis-ci` logs for the `Rub Gem` update here [https://travis-ci.com/github/sambacha/yip_validator/builds/181226022](https://travis-ci.com/github/sambacha/yip_validator/builds/181226022)
+
+```bash
+total:2, valid:2, invalid:0, errors:0
+	statuses: [["Withdrawn", 1], ["Implemented", 1]]
+  raises exception if it includes invalid yips
+spec/fixtures/invalid/yip-7.md is NOT valid:	 {:status=>["is not included in the list"]}
+
+```
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Link to discussion: [gov.yearn.finance/t/proposal-add-new-statuses-to-yip-proposals-non-protocol-change/3608](https://gov.yearn.finance/t/proposal-add-new-statuses-to-yip-proposals-non-protocol-change/3608)

Relevant PR's:
https://github.com/iearn-finance/yip_validator/pull/1


```yaml
yip: <to be assigned>
title: improve-yip-categories
status: WIP 
author: sam bacha, @sambacha <sam@freighttrust.com>
discussions-to: https://gov.yearn.finance/t/proposal-add-new-statuses-to-yip-proposals-non-protocol-change/3608

created: 2020-08-24
requires (*optional): <YIP number(s)>
implementation (*optional): <Added if YIP passes>
```



## Simple Summary
<!--"If you can't explain it simply, you don't understand it well enough." Simply describe the outcome the proposed changes intends to achieve. This should be non-technical and accessible to a casual community member.-->

Add new `status`(s) to `YIPs` so that author(s) may better manage their `YIPs` in the context of community collaboration and so that governance is given the proper procedures to foster community cooperation.

## Abstract
<!--A short (~200 word) description of the proposed change, the abstract should clearly describe the proposed change. This is what *will* be done if the YIP is implemented, not *why* it should be done or *how* it will be done. If the YIP proposes deploying a new contract, write, "we propose to deploy a new contract that will do x".-->


This will *only* add to the current state of `proposal YIPs` in that it only changes the _potential_ `statuses` available of a `YIP`. It does not add any `protocol` changes: only documentation and governance procedures (off chain only).

I proposal the following changes to reflect a new state of possible 'YIPs':

1. Modifying YIP Templates
2. Modifying YIP Validator Gemfile
3. Modifying YIP README file


## Motivation
<!--This is the problem statement. This is the *why* of the YIP. It should clearly explain *why* the current state of the protocol is inadequate.  It is critical that you explain *why* the change is needed, if the YIP proposes changing how something is calculated, you must address *why* the current calculation is inaccurate or wrong. This is not the place to describe how the YIP will address the issue!-->
> The current state of procedures for `YIPS` is inadequate as it unnecessarily limits the possible outcomes of a proposed `YIP` while not affording both the author(s) nor the governance council flexibility in being able to deal with community driven `YIPs`

This is a *documentation* and *procedure* change. In fact there is no explicit description for proposing such changes in governance *(that I could find).*

This change is needed as it better explains the *intent* of the YIP format to author(s). It also provides for governance additional functionality in their procedures so as to not potentially 'alienate' author(s) by rejecting a YIP when it could have been withdrawn. This ensures that also the author(s) are active in the process of their submitted proposal and in the larger community (in so far as they are knowledgable about other potentially competing YIPS.)

## Specification

*Additions in 'BOLD'*

Proposed - a YIP that is ready to be reviewed in a governance call.
Approved - a YIP that has been accepted for implementation by the yEarn community.
Implemented - a YIP that has been released to mainnet.
Rejected - a YIP that has been rejected.
**Withdrawn - a YIP that has been withdrawn by the author(s).**
**Deferred - a YIP that governance has decided to wait for another YIP/some other change that should be bundled with it together**
**Moribund - a YIP that was once Implemented. It is now Obsolete 'AND' requires no explicit replacement.**

The "Withdrawn" status is similar - it means that the YIP author has decided that the YIP is actually a 'bad' idea, or has accepted that a competing proposal is a better alternative.


### Workflow Specification
```
Proposed -> Approved -> Implemented
  ^                     |
  +----> Rejected       +----> Moribund
  |
  +----> Withdrawn
  v
Deferred
```


#### New Statuses for YIPs 

> To be added are the following

[Withdrawn](/EfryOm69Sf-iM4TCasQuJA)
[Moribund](/igo8dKVnRjq8Xxyql9GOxQ)
[Deferred](/MPwJ8Sa2Se-7qFBlEvDEBw)


### Overview
<!--This is a high level overview of *how* the YIP will solve the problem. The overview should clearly describe how the new feature will be implemented.-->

#### New YIP statuses
- Withdrawn
Means that the YIP author has decided that the YIP is actually a bad idea, or has accepted that a competing proposal is a better alternative.
- Moribund
Obsolete and requires no explicit replacement, it SHOULD be marked "Moribund"
- Deferred
Governance placed status upon a YIP that means that they would like to know more information, or that they would like to see if the author(s) can work with another proposed YIP and combine it into a single YIP, etc.


### Rationale

The reasoning behind this is that it is unclear what will happen to a YIP should material facts change during its initial formal proposal and when its actually voted on by governance. Changes may be introduced between then, and the author may want to withdraw the proposal. This also frees up the governance council in that they are no longer obligated to reject every single YIP that may no longer be relevant, instead sharing the responsibility with the actual author(s). 

### Technical Specification
<!--
NOTE: NO PROTOCOL CHANGES ARE PROPOSED 
THE ONLY TECHNICAL CHANGES ARE IN THE RUBY VALIDATION PROCESS FOR YIPS
-->
Technical implementation involves:

* changes in the validation Gemfile 
* changes in the template `.md` file

#### Changes in Template `.md` file

Below is a sample `.yaml` file to illustrate the _new_ header that should be used in the `yip-template.md` file

```yaml
---
YIP: <YIP number>
Title: <YIP title>
Author: < firstName, lastName, @githubUsrName, contact@address.com >
Type: <Informational | Standards Track>
Status: <WIP | Proposed | Approved | Deferred | Withdrawn | Rejected |
           Implemented | Replaced | Moribund>
    Version: <major>[.<minor>]
    Created: <date created on, in ISO 8601 (yyyy-mm-dd) format>
    Requires (*optional): <YIP number(s)>
    Implementation (*optional): <Added if YIP passes>

Discussions-to: <Create a new thread on https://gov.yearn.finance/ and drop the link here>

* Requires: <YIP numbers>
* Replaces: <YIP numbers>
* Replaced-By: <YIP number>
---
```

#### YIP Validator (Ruby Gem)

> current version: `1.0.2`, should be bumped to `1.1.0`
Changes located [github.com/iearn-finance/yip_validator/blob/master/lib/yip_validator/validator.rb#L25](https://github.com/iearn-finance/yip_validator/blob/master/lib/yip_validator/validator.rb#L25)

```ruby
    validates_inclusion_of :status, in: ['WIP', 'Proposed', 'Approved', 'Implemented', 'Rejected']
```
```ruby
    validates_inclusion_of :status, in: ['WIP', 'Proposed', 'Approved', 'Implemented', 'Rejected', 'Withdrawn', 'Deferred', 'Moribund']
```

See Files Changed here [https://github.com/sambacha/yip_validator/tree/YIP-Proposed](https://github.com/sambacha/yip_validator/tree/YIP-Proposed)

### Test Cases

See `travis-ci` logs for the `Rub Gem` update here [https://travis-ci.com/github/sambacha/yip_validator/builds/181226022](https://travis-ci.com/github/sambacha/yip_validator/builds/181226022)

```bash
total:2, valid:2, invalid:0, errors:0
	statuses: [["Withdrawn", 1], ["Implemented", 1]]
  raises exception if it includes invalid yips
spec/fixtures/invalid/yip-7.md is NOT valid:	 {:status=>["is not included in the list"]}

```

## Copyright
Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
