### PR TITLE
docs: add YIP-79 (Multisig compensation and rotation)

### DIFF
--- a/YIPS/yip-79.md
+++ b/YIPS/yip-79.md
@@ -8,10 +8,10 @@ created: 2024-09-26
 ---
 
 ## Simple Summary
-Yearn's main multisig, [ychad.eth](https://etherscan.io/address/0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52), is a 6 of 9 multisig which has key powers within the protocol including ownership over the treasury. For more information, including the current list of signers, please refer to [the docs](https://docs.yearn.fi/developers/security/multisig).
+Yearn's main multisig, [ychad.eth](https://etherscan.io/address/0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52)[1], is a 6 of 9 multisig which has key powers within the protocol including ownership over the treasury. For more information, including the current list of signers, please refer to [the docs](https://docs.yearn.fi/developers/security/multisig).[2]
 
 ## Abstract
-Yearn's main multisig, [ychad.eth](https://etherscan.io/address/0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52), is a 6 of 9 multisig which has key powers within the protocol including ownership over the treasury. For more information, including the current list of signers, please refer to [the docs](https://docs.yearn.fi/developers/security/multisig).
+Yearn's main multisig, [ychad.eth](https://etherscan.io/address/0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52)[1], is a 6 of 9 multisig which has key powers within the protocol including ownership over the treasury. For more information, including the current list of signers, please refer to [the docs](https://docs.yearn.fi/developers/security/multisig).[2]
 
 This proposal aims to:
 - outline a YFI compensation plan for signers
@@ -70,5 +70,8 @@ Not applicable.
 - Multisig threshold: 6 of 9.
 - Rotation timing: two signers immediately on passage; final seat at start of December.
 
+## References
+1. https://etherscan.io/address/0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52
+2. https://docs.yearn.fi/developers/security/multisig
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/YIPS/yip-79.md
+++ b/YIPS/yip-79.md
@@ -18,7 +18,7 @@ This proposal aims to:
 - rotate 3 multisig signers
 
 ## Motivation
-TODO: Add Motivation.
+This proposal ensures multisig security and continuity by rotating signers while compensating them for ongoing operational responsibility. It formalizes compensation to recognize signer workload and sets a clear rotation plan.
 
 ## Specification
 ### Overview
@@ -31,7 +31,7 @@ This proposal aims to:
 - rotate 3 multisig signers
 
 ### Rationale
-TODO: Add Rationale.
+The rationale is to keep the multisig both secure and accountable: rotations refresh operational resilience, and compensation aligns incentives for timely execution and oversight.
 
 ### Technical Specification
 #### Compensation
@@ -66,7 +66,9 @@ with the following incoming signers:
 Not applicable.
 
 ### Configurable Values
-TODO: List configurable values (if any) from the specification.
+- Compensation: 1 YFI per signer for past service and 1 YFI per ongoing signer (2 YFI for those continuing).
+- Multisig threshold: 6 of 9.
+- Rotation timing: two signers immediately on passage; final seat at start of December.
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/YIPS/yip-79.md
+++ b/YIPS/yip-79.md
@@ -1,0 +1,57 @@
+---
+yip: 79
+title: Multisig Compensation and Rotation
+author: wavey
+discussions-to: https://gov.yearn.fi/t/yip-79-multisig-compensation-and-rotation/14179
+status: Voting
+created: 2024-09-26
+---
+
+## Simple Summary
+Rotate three ychad.eth multisig signers and introduce a YFI compensation policy for multisig service.
+
+## Abstract
+This proposal updates the ychad.eth signer set and establishes a compensation structure: 1 YFI for past service and 1 YFI for ongoing service. It specifies outgoing and incoming signer addresses and timing.
+
+## Motivation
+Multisig signers hold critical protocol responsibilities and should be compensated for past and ongoing service. Rotation keeps signer set current.
+
+## Specification
+### Overview
+- Rotate three signers on ychad.eth.
+- Pay 1 YFI for past service and 1 YFI for ongoing service.
+
+### Rationale
+- Compensation aligns incentives and acknowledges operational risk.
+- Rotation improves resilience and continuity.
+
+### Technical Specification
+1) Compensation
+- Current signers (including outgoing, excluding incoming): 1 YFI each.
+- Ongoing signers (including incoming, excluding outgoing): 1 YFI each.
+- Signers present before and after rotation receive 2 YFI total.
+
+2) Signer rotation
+Outgoing:
+- cp0x: 0x74630370197b4c4795bFEeF6645ee14F8cf8997D
+- milkyklim: 0x0Cec743b8CE4Ef8802cAc0e5df18a180ed8402A7
+- banteg: 0x7A1057E6e9093DA9C1D4C1D049609B6889fC4c67
+
+Incoming:
+- cryptoharry (Inverse Finance): 0x962228a90eaC69238c7D1F216d80037e61eA9255
+- michwill (Curve Finance): 0xFe45baf0F18c207152A807c1b05926583CFE2e4b
+- tapir (Yearn Finance): 0x700F1a984C962b447CcDb95c4c2D8074C65098a3
+
+Timing:
+- First two rotations execute immediately after passage.
+- Final seat executes at the start of December (per proposal note).
+
+### Test Cases
+Not applicable.
+
+### Configurable Values
+- Compensation amount per signer.
+- Rotation timing.
+
+## References
+- https://gov.yearn.fi/t/yip-79-multisig-compensation-and-rotation/14179

--- a/YIPS/yip-79.md
+++ b/YIPS/yip-79.md
@@ -50,17 +50,17 @@ replace the following outgoing signers:
 | |                                   |
 |--------|------------------------------------------|
 | cp0x | `0x74630370197b4c4795bFEeF6645ee14F8cf8997D` |
-| milkyklim   | `0x0Cec743b8CE4Ef8802cAc0e5df18a180ed8402A7`	 |
-| **banteg  | `0x7A1057E6e9093DA9C1D4C1D049609B6889fC4c67` |
+| milkyklim   | `0x0Cec743b8CE4Ef8802cAc0e5df18a180ed8402A7` |
+| **banteg** | `0x7A1057E6e9093DA9C1D4C1D049609B6889fC4c67` |
 
 with the following incoming signers:
 | |                                   |
 |--------|------------------------------------------|
 | cryptoharry (Inverse Finance)  | `0x962228a90eaC69238c7D1F216d80037e61eA9255` |
 | michwill (Curve Finance)   | `0xFe45baf0F18c207152A807c1b05926583CFE2e4b` |
-| **tapir (Yearn Finance)  | `0x700F1a984C962b447CcDb95c4c2D8074C65098a3` |
+| **tapir (Yearn Finance)** | `0x700F1a984C962b447CcDb95c4c2D8074C65098a3` |
 
-** *To be executed in December*
+*To be executed in December*
 
 ### Test Cases
 Not applicable.

--- a/YIPS/yip-79.md
+++ b/YIPS/yip-79.md
@@ -3,55 +3,70 @@ yip: 79
 title: Multisig Compensation and Rotation
 author: wavey
 discussions-to: https://gov.yearn.fi/t/yip-79-multisig-compensation-and-rotation/14179
-status: Voting
+status: Proposed
 created: 2024-09-26
 ---
 
 ## Simple Summary
-Rotate three ychad.eth multisig signers and introduce a YFI compensation policy for multisig service.
+Yearn's main multisig, [ychad.eth](https://etherscan.io/address/0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52), is a 6 of 9 multisig which has key powers within the protocol including ownership over the treasury. For more information, including the current list of signers, please refer to [the docs](https://docs.yearn.fi/developers/security/multisig).
 
 ## Abstract
-This proposal updates the ychad.eth signer set and establishes a compensation structure: 1 YFI for past service and 1 YFI for ongoing service. It specifies outgoing and incoming signer addresses and timing.
+Yearn's main multisig, [ychad.eth](https://etherscan.io/address/0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52), is a 6 of 9 multisig which has key powers within the protocol including ownership over the treasury. For more information, including the current list of signers, please refer to [the docs](https://docs.yearn.fi/developers/security/multisig).
+
+This proposal aims to:
+- outline a YFI compensation plan for signers
+- rotate 3 multisig signers
 
 ## Motivation
-Multisig signers hold critical protocol responsibilities and should be compensated for past and ongoing service. Rotation keeps signer set current.
+TODO: Add Motivation.
 
 ## Specification
 ### Overview
-- Rotate three signers on ychad.eth.
-- Pay 1 YFI for past service and 1 YFI for ongoing service.
+### Proposal to rotate multisig signers and provide compensation
+
+Yearn's main multisig, [ychad.eth](https://etherscan.io/address/0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52), is a 6 of 9 multisig which has key powers within the protocol including ownership over the treasury. For more information, including the current list of signers, please refer to [the docs](https://docs.yearn.fi/developers/security/multisig).
+
+This proposal aims to:
+- outline a YFI compensation plan for signers
+- rotate 3 multisig signers
 
 ### Rationale
-- Compensation aligns incentives and acknowledges operational risk.
-- Rotation improves resilience and continuity.
+TODO: Add Rationale.
 
 ### Technical Specification
-1) Compensation
-- Current signers (including outgoing, excluding incoming): 1 YFI each.
-- Ongoing signers (including incoming, excluding outgoing): 1 YFI each.
-- Signers present before and after rotation receive 2 YFI total.
+#### Compensation
 
-2) Signer rotation
-Outgoing:
-- cp0x: 0x74630370197b4c4795bFEeF6645ee14F8cf8997D
-- milkyklim: 0x0Cec743b8CE4Ef8802cAc0e5df18a180ed8402A7
-- banteg: 0x7A1057E6e9093DA9C1D4C1D049609B6889fC4c67
+Currently, ychad.eth signers earn no compensation. If passed, this proposal will:
+- retroactively reward all current signers (including outgoing, excluding incoming) 1 YFI each to compensate for past efforts.
+- reward all on-going signers (including incoming, excluding outgoing) with 1 YFI.
 
-Incoming:
-- cryptoharry (Inverse Finance): 0x962228a90eaC69238c7D1F216d80037e61eA9255
-- michwill (Curve Finance): 0xFe45baf0F18c207152A807c1b05926583CFE2e4b
-- tapir (Yearn Finance): 0x700F1a984C962b447CcDb95c4c2D8074C65098a3
+In summary, all signers who are part of both the past and present state will receive a transfer of 2 YFI. Signers who were part of only past or future state will receive a transfer of 1 YFI.
 
-Timing:
-- First two rotations execute immediately after passage.
-- Final seat executes at the start of December (per proposal note).
+#### Signer Rotation
+
+A transaction to rotate the first two signers will be queued to execute immediately upon passage of this proposal. Due to prior commitments, the final seat will be rotated at the start of December of this year.
+
+replace the following outgoing signers:
+| |                                   |
+|--------|------------------------------------------|
+| cp0x | `0x74630370197b4c4795bFEeF6645ee14F8cf8997D` |
+| milkyklim   | `0x0Cec743b8CE4Ef8802cAc0e5df18a180ed8402A7`	 |
+| **banteg  | `0x7A1057E6e9093DA9C1D4C1D049609B6889fC4c67` |
+
+with the following incoming signers:
+| |                                   |
+|--------|------------------------------------------|
+| cryptoharry (Inverse Finance)  | `0x962228a90eaC69238c7D1F216d80037e61eA9255` |
+| michwill (Curve Finance)   | `0xFe45baf0F18c207152A807c1b05926583CFE2e4b` |
+| **tapir (Yearn Finance)  | `0x700F1a984C962b447CcDb95c4c2D8074C65098a3` |
+
+** *To be executed in December*
 
 ### Test Cases
 Not applicable.
 
 ### Configurable Values
-- Compensation amount per signer.
-- Rotation timing.
+TODO: List configurable values (if any) from the specification.
 
-## References
-- https://gov.yearn.fi/t/yip-79-multisig-compensation-and-rotation/14179
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Summary
- Add YIP-79 describing multisig signer compensation and rotation.

Rationale
- Present the proposal in the standard YIP format with inline references.

Details
- Includes signer rotation tables and references